### PR TITLE
Create BeansCascade.json

### DIFF
--- a/Formats/Modern/Archetypes/BeansCascade.json
+++ b/Formats/Modern/Archetypes/BeansCascade.json
@@ -1,0 +1,14 @@
+{
+  "Name": "Beans Cascade",
+  "IncludeColorInName": false,
+  "Conditions": [
+    {
+      "Type": "InMainboard",
+      "Cards": ["Shardless Agent"]
+    },
+    {
+      "Type": "InMainboard",
+      "Cards": ["Up the Beanstalk"]
+    }
+  ]
+}


### PR DESCRIPTION
Ran the tests, it only changed 11 decks classified as WURG(B) Midrange/Control to Beans Cascade.