### PR TITLE
New archetype: Artifact Aggro

### DIFF
--- a/Formats/Standard/Archetypes/ArtifactAggro.json
+++ b/Formats/Standard/Archetypes/ArtifactAggro.json
@@ -1,0 +1,10 @@
+{
+  "Name": "Artifact Aggro",
+  "IncludeColorInName": true,
+  "Conditions": [
+    {
+      "Type": "InMainboard",
+      "Cards": ["Teething Wurmlet"]
+    }
+  ]
+}


### PR DESCRIPTION
New archetype came up in standard. It made the "Unknown" decks go above the acceptable threshold.