### PR TITLE
Add Ensoul Artifact Archetype

### DIFF
--- a/Formats/Pioneer/Archetypes/ArtifactAggro.json
+++ b/Formats/Pioneer/Archetypes/ArtifactAggro.json
@@ -4,7 +4,7 @@
   "Conditions": [
     {
       "Type": "OneOrMoreInMainboard",
-      "Cards": ["Patchwork Automaton","Gingerbrute"]
+      "Cards": ["Patchwork Automaton", "Gingerbrute"]
     },
     {
       "Type": "DoesNotContain",
@@ -13,18 +13,6 @@
     {
       "Type": "DoesNotContain",
       "Cards": ["Colossus Hammer"]
-    }
-  ],
-  "Variants": [
-    {
-      "Name": "Ensoul",
-      "IncludeColorInName": true,
-      "Conditions": [
-        {
-          "Type": "InMainboard",
-          "Cards": ["Ensoul Artifact"]
-        }
-      ]
     }
   ]
 }

--- a/Formats/Pioneer/Archetypes/ArtifactControl.json
+++ b/Formats/Pioneer/Archetypes/ArtifactControl.json
@@ -1,0 +1,11 @@
+{
+  "Name": "Artifacts Control",
+  "IncludeColorInName": true,
+  "Conditions": [
+    {
+      "Type": "InMainboard",
+      "Cards": ["Whir of Invention"]
+    }
+  ]
+}
+

--- a/Formats/Pioneer/Archetypes/EnsoulArtifact.json
+++ b/Formats/Pioneer/Archetypes/EnsoulArtifact.json
@@ -1,0 +1,10 @@
+{
+  "Name": "Ensoul Artifact",
+  "IncludeColorInName": true,
+  "Conditions": [
+    {
+      "Type": "OneOrMoreInMainboard",
+      "Cards": ["Ensoul Artifact"]
+    }
+  ]
+}


### PR DESCRIPTION
It looks like new iterations of the ensoul artifact deck went away from the artifact aggro archetype. Hence dedicating a new archetype file for it.

cc @Lardach 